### PR TITLE
Add A3I5 texture format support

### DIFF
--- a/models/scene.c
+++ b/models/scene.c
@@ -475,8 +475,9 @@ void build_meshes(SCENE* scene, Mesh* meshes, Dlist* dlists, u8* scenedata, unsi
 		0 = 2bit palettised
 		1 = 4bit palettised
 		2 = 8bit palettised
-		4 = 8bit greyscale
+		4 = 8bit A5I3
 		5 = 16bit RGBA
+		6 = 8bit A3I5
 
 	There may be more, but these are the only ones used by Metroid
 
@@ -590,6 +591,18 @@ void make_textures(SCENE* scn, Material* materials, unsigned int num_materials, 
 				u32 g = ((col >>  5) & 0x1F) << 3;
 				u32 b = ((col >> 10) & 0x1F) << 3;
 				u32 a = ((col & 0x8000) ? 0x00 : 0xFF) * alpha;
+				image[p] = (r << 0) | (g << 8) | (b << 16) | (a << 24);
+			}
+		} else if(tex->format == 6) {			// A3I5
+			u32 p;
+			for(p = 0; p < num_pixels; p++) {
+				u8 entry = texels[p];
+				u8 i = (entry & 0x1F);
+				u16 col = get16bit_LE((u8*)&paxels[i]);
+				u32 r = ((col >>  0) & 0x1F) << 3;
+				u32 g = ((col >>  5) & 0x1F) << 3;
+				u32 b = ((col >> 10) & 0x1F) << 3;
+				u32 a = ((entry >> 5) / 7.0 * 255.0) * alpha;
 				image[p] = (r << 0) | (g << 8) | (b << 16) | (a << 24);
 			}
 		} else {


### PR DESCRIPTION
The already implemented A5I3 does `AND` with `0x7` (`0000111`, 3 bits) to get the palette index, as well as `>> 3` and dividing by `0x1F` (`00011111`, 5 bits) to get the alpha value.

A3I5 does `AND` with `0x1F` (`00011111`, 5 bits) to get the palette index, as well as `>> 5` and dividing by `0x7` (`00000111`, 3 bits) to get the alpha value.

I verified this format by adding this code to dsgraph and rendering one of the few models that uses A3I5 (texture format 6), the unused Temroid enemy.

![image](https://user-images.githubusercontent.com/2163967/69787629-eac29080-118a-11ea-8185-68577e571b84.png)

Fixes #1 